### PR TITLE
feat(components): add useIAMRole for IAM role authentication (C# base)

### DIFF
--- a/openapi/v1.0.0.yaml
+++ b/openapi/v1.0.0.yaml
@@ -4026,17 +4026,25 @@ components:
               default: ""
               type: string
               maxLength: 100
+            useIAMRole:
+              description: >
+                Use IAM role for authentication instead of access/secret keys.
+                When set to `true`, send an empty string for both `accessKey` and
+                `secretKey`.
+              example: true
+              default: false
+              type: boolean
             accessKey:
-              description: Access key for the bucket.
+              description: >
+                Access key for the bucket. When `useIAMRole` is `true`, send an empty string.
               example: AKIAIOSFODNN7EXAMPLE
               type: string
-              minLength: 1
               maxLength: 100
             secretKey:
-              description: Secret key for the bucket.
+              description: >
+                  Secret key for the bucket. When `useIAMRole` is `true`, send an empty string.
               example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
               type: string
-              minLength: 1
               maxLength: 100
           required:
             - name
@@ -4145,17 +4153,25 @@ components:
               default: ""
               type: string
               maxLength: 100
+            useIAMRole:
+              description: >
+                Use IAM role for authentication instead of access/secret keys.
+                When set to `true`, send an empty string for both `accessKey` and
+                `secretKey`.
+              example: true
+              default: false
+              type: boolean
             accessKey:
-              description: Access key for the bucket.
+              description: >
+                Access key for the bucket. When `useIAMRole` is `true`, send an empty string.
               example: AKIAIOSFODNN7EXAMPLE
               type: string
-              minLength: 1
               maxLength: 100
             secretKey:
-              description: Secret key for the bucket.
+              description: >
+                Secret key for the bucket. When `useIAMRole` is `true`, send an empty string.
               example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
               type: string
-              minLength: 1
               maxLength: 100
           required:
             - name
@@ -4428,6 +4444,14 @@ components:
               type: string
               description: Path prefix inside the bucket.
               example: raw-assets
+            useIAMRole:
+              description: >
+                Whether the origin authenticates using an IAM role instead of
+                access/secret keys. When `true`, the access and secret keys are
+                empty.
+              example: true
+              default: false
+              type: boolean
             id:
               readOnly: true
               description:
@@ -4534,6 +4558,14 @@ components:
               type: string
               description: Path prefix inside the bucket.
               example: raw-assets
+            useIAMRole:
+              description: >
+                Whether the origin authenticates using an IAM role instead of
+                access/secret keys. When `true`, the access and secret keys are
+                empty.
+              example: true
+              default: false
+              type: boolean
             id:
               readOnly: true
               description:

--- a/openapi/v1.0.0.yaml
+++ b/openapi/v1.0.0.yaml
@@ -4447,8 +4447,7 @@ components:
             useIAMRole:
               description: >
                 Whether the origin authenticates using an IAM role instead of
-                access/secret keys. When `true`, the access and secret keys are
-                empty.
+                access/secret keys.
               example: true
               default: false
               type: boolean
@@ -4561,8 +4560,7 @@ components:
             useIAMRole:
               description: >
                 Whether the origin authenticates using an IAM role instead of
-                access/secret keys. When `true`, the access and secret keys are
-                empty.
+                access/secret keys.
               example: true
               default: false
               type: boolean


### PR DESCRIPTION
Adds the new optional `useIAMRole` boolean field (default `false`) to the S3 and Cloudinary Backup origin variants in both `OriginRequest` and `OriginResponse`, on top of the `csharp` base branch.

Mirrors the change in #(feat/use-iam-role-api-changes) which targets `main`.

### Details
- `useIAMRole` (optional, default `false`) added to S3 and Cloudinary Backup request/response variants.
- `accessKey` / `secretKey` remain **required** to avoid breaking the Go and Java SDK types; the underlying API change is non-breaking.
- Removed `minLength: 1` on `accessKey` / `secretKey` so an empty string is valid when `useIAMRole` is `true`.
- Field descriptions updated to explain that an empty string should be sent for `accessKey` / `secretKey` when `useIAMRole` is `true`.