### PR TITLE
fix: colorize default intensity value to 100

### DIFF
--- a/openapi/v1.0.0.yaml
+++ b/openapi/v1.0.0.yaml
@@ -7590,7 +7590,7 @@ components:
           description: |
             Applies a color tint to the image. Accepts color and intensity as optional parameters.
             - `co-color` - Color to apply (e.g., `red`, `blue`, `FF0022`). Default is gray color.
-            - `in-intensity` - Intensity of the color (0-100). Default is 35.
+            - `in-intensity` - Intensity of the color (0-100). Default is 100.
             See [Colorize](https://imagekit.io/docs/effects-and-enhancements#colorize---e-colorize).
 
         distort:


### PR DESCRIPTION
Mirrors the colorize fix already merged into `main` (#14) onto the `csharp` base branch.

Changes the documented default for the colorize `in-intensity` parameter from `35` to `100` to match the actual API behavior.