### PR TITLE
feat: add optional description field to custom metadata field API

### DIFF
--- a/openapi/v1.0.0.yaml
+++ b/openapi/v1.0.0.yaml
@@ -281,6 +281,11 @@ paths:
                 label:
                   type: string
                   description: Human readable name of the custom metadata field. This should be unique across all non deleted custom metadata fields. This name is displayed as form field label to the users while setting field value on an asset in the media library UI.
+                description:
+                  type: string
+                  maxLength: 500
+                  description: |
+                    Optional description for the custom metadata field. Can be up to 500 characters. This is shown as a hint to the users while setting the field's value on an asset in the media library UI.
                 schema:
                   type: object
                   required:
@@ -683,7 +688,7 @@ paths:
       operationId: update-existing-field
       summary: Update existing field
       description: |
-        This API updates the label or schema of an existing custom metadata field.
+        This API updates the label, description, or schema of an existing custom metadata field.
       parameters:
         - description: |
             Should be a valid custom metadata field id.
@@ -701,6 +706,11 @@ paths:
                 label:
                   type: string
                   description: Human readable name of the custom metadata field. This should be unique across all non deleted custom metadata fields. This name is displayed as form field label to the users while setting field value on an asset in the media library UI. This parameter is required if `schema` is not provided.
+                description:
+                  type: string
+                  maxLength: 500
+                  description: |
+                    Optional description for the custom metadata field. Can be up to 500 characters. Send an empty string to clear an existing description. This is shown as a hint to the users while setting the field's value on an asset in the media library UI.
                 schema:
                   type: object
                   description: |
@@ -792,8 +802,10 @@ paths:
                     type: string
                     examples:
                       - Cannot update a deleted custom metadata fields.
-                      - Either label or schema should be provided.
+                      - Either label, description or schema should be provided.
                       - A custom metadata field with this label already exists.
+                      - description must be a string
+                      - description must be at most 500 characters
                       - Invalid schema object.
                       - Name cannot be updated.
                       - Missing id parameter.
@@ -6694,6 +6706,11 @@ components:
           type: string
           description: |
             Human readable name of the custom metadata field. This name is displayed as form field label to the users while setting field value on the asset in the media library UI.
+        description:
+          type: string
+          maxLength: 500
+          description: |
+            Optional description of the custom metadata field. Only present when a description has been set. Shown as a hint to the users while setting the field's value on an asset in the media library UI.
         schema:
           type: object
           description: An object that describes the rules for the custom metadata field value.


### PR DESCRIPTION
## Summary

Introduces the optional `description` field on the **custom metadata field** public API, mirroring the backend change in image-server-dashboard [PR #106](https://github.com/imagekit-internal/image-server-dashboard/pull/106).

`description` is a **string, max 500 characters, optional** and is an **independent** field — it does not affect the existing `label`/`schema` mutual-requirement on update.

## Changes (`openapi/v1.0.0.yaml`)

- **POST `/v1/customMetadataFields`** — accept optional `description` in the request body.
- **PATCH `/v1/customMetadataFields/{id}`** — accept optional `description` (send an empty string to clear an existing description). Updated the operation summary and the 400 error examples to match the backend (`Either label, description or schema should be provided.`, `description must be a string`, `description must be at most 500 characters`).
- **`CustomMetadataField` response schema** — expose `description` (present only when set; not in `required`). This flows to the GET list, POST 201, and PATCH 200 responses.

No `stainless-config/main.yaml` change is required — the model derives from the schema component and inline request bodies.

## Validation

- YAML parses cleanly (`openapi: 3.1.0`).
- `description` present with `maxLength: 500` in POST request, PATCH request, and the response component.
- `description` correctly **absent** from the component's `required` list.
- `label`/`schema` required-if wording unchanged (no coupling to `description`).
- All local `$ref` targets still resolve.